### PR TITLE
Fix escaping HTML `&lt;`

### DIFF
--- a/website/templates/docs.html
+++ b/website/templates/docs.html
@@ -594,9 +594,9 @@ fn main() {
 	db := new_db()
 	users_repo := new_repo&lt;User>(db)
 	posts_repo := new_repo&lt;Post>(db)
-	<comment>// find_by_id<User> is inferred from users_repo:</comment>
+	<comment>// find_by_id&lt;User> is inferred from users_repo:</comment>
 	user := users_repo.find_by_id(1)? 
-	<comment>// find_by_id<Post> is inferred from posts_repo:</comment>
+	<comment>// find_by_id&lt;Post> is inferred from posts_repo:</comment>
 	post := posts_repo.find_by_id(1)? 
 	println(user.name)
 	println(post.text)


### PR DESCRIPTION
Oops, my fault. BTW any chance we could change to MarkDown (like `README.md`) for generating `docs.html`? I can't promise but I might be able to convert `docs.html` to markdown for you.